### PR TITLE
Add libvpl testing

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sudo apt install -y vainfo ffmpeg libflite1 liboss4-salsa2
+sudo apt install -y vainfo libvpl-dev ffmpeg libflite1 liboss4-salsa2

--- a/checkbox-provider-media/units/jobs.pxu
+++ b/checkbox-provider-media/units/jobs.pxu
@@ -287,6 +287,8 @@ category_id: media-kobuk
 flags: simple
 user: root
 _summary: Run the {{ binname }} test from libvpl
+requires:
+  executable.name == "{{binname}}"
 environ:
   # necessary for local mode
   XDG_SESSION_TYPE

--- a/checkbox-provider-media/units/jobs.pxu
+++ b/checkbox-provider-media/units/jobs.pxu
@@ -1,3 +1,28 @@
+id: libvpl
+plugin: resource
+command:
+    echo 'binname: hello-decode'
+    echo 'command: sudo hello-decode -i /usr/share/vpl/examples/content/cars_320x240.h265'
+    echo
+    echo 'binname: hello-encode'
+    echo 'command: sudo hello-encode -i /usr/share/vpl/examples/content/cars_320x240.i420 -w 320 -h 240'
+    echo
+    echo 'binname: 01_transition_vpl'
+    echo 'command: 01_transition_vpl'
+    echo
+    echo 'binname: hello-sharing-vaapi-export'
+    echo 'command: sudo hello-sharing-vaapi-export -i /usr/share/vpl/examples/content/cars_320x240.h265'
+    echo
+    echo 'binname: hello-sharing-vaapi-import'
+    echo 'command: sudo hello-sharing-vaapi-import -i /usr/share/vpl/examples/content/cars_320x240.i420 -w 320 -h 240'
+    echo
+    echo 'binname: hello-vpp'
+    echo 'command: sudo hello-vpp -i /usr/share/vpl/examples/content/cars_320x240.i420 -w 320 -h 240'
+    echo
+    echo 'binname: hello-encode-jpeg'
+    echo 'command: sudo hello-encode-jpeg -i /usr/share/vpl/examples/content/cars_320x240.nv12 -w 320 -h 240 -nv12'
+    echo
+
 id: va
 plugin: resource
 command:
@@ -251,3 +276,23 @@ command:
   then
     exit 1
   fi
+
+unit: template
+template-resource: libvpl
+template-filter: libvpl.binname != ''
+template-engine: jinja2
+template-unit: job
+id: media_kobuk_libvpl_{{ binname }}
+category_id: media-kobuk
+flags: simple
+user: root
+_summary: Run the {{ binname }} test from libvpl
+environ:
+  # necessary for local mode
+  XDG_SESSION_TYPE
+  XDG_RUNTIME_DIR
+  NORMAL_USER
+estimated_duration: 1m
+command:
+  echo "{{ command }}"
+  {{ command }}

--- a/checkbox-provider-media/units/test-plan.pxu
+++ b/checkbox-provider-media/units/test-plan.pxu
@@ -4,9 +4,11 @@ _name: Media test plan for hardware encode and decode
 include:
   media_kobuk.*
   media_kobuk_smoke.*
+  media_kobuk_libvpl.*
 bootstrap_include:
     com.canonical.certification::executable
     com.canonical.certification::snap
     graphics_card
     va
+    libvpl
     mediasource


### PR DESCRIPTION
Note: If run, this should be tested only on systems which have my currently-under-review libvpl and onevpl-intel-gpu versions. This is because the examples were not built into the libvpl-dev package until now. 

The PRs for this can be found here:
https://github.com/canonical/kobuk-gfx-libvpl/pull/5
https://github.com/canonical/kobuk-gfx-onevpl-intel-gpu/pull/9

My test runs on 2 different machines showed full passing on RPL:
```
  job passed   : Run the 01_transition_vpl test from libvpl
  job passed   : Run the hello-sharing-vaapi-export test from libvpl
  job passed   : Run the hello-sharing-vaapi-import test from libvpl
  job passed   : Run the hello-vpp test from libvpl
  job passed   : Run the hello-encode-jpeg test from libvpl
```
And a couple failures on ADL:
```
  job passed   : Run the hello-decode test from libvpl
  job failed   : Run the hello-encode test from libvpl
  job passed   : Run the 01_transition_vpl test from libvpl
  job passed   : Run the hello-sharing-vaapi-export test from libvpl
  job failed   : Run the hello-sharing-vaapi-import test from libvpl
  job passed   : Run the hello-vpp test from libvpl
  job passed   : Run the hello-encode-jpeg test from libvpl
```

Both failures here were related to encode and gave valid non-test-related failure messages, so this is likely either a bug or support limitation